### PR TITLE
Simplify implementation of Strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dex"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Rohit Kumar <letmutx@gmail.com>"]
 edition = "2018"
 description = "Rust library for parsing dex files"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Most of the functionality to access the data structures in the file is implement
 ## Usage
 Add to your `Cargo.toml`:
 ```
-dex = "0.2.2"
+dex = "0.2.3"
 ```
 
 ## Documentation

--- a/src/class.rs
+++ b/src/class.rs
@@ -6,7 +6,6 @@ use scroll::ctx;
 use scroll::{Pread, Uleb128};
 
 use crate::annotation::AnnotationsDirectoryItem;
-use crate::cache::Ref;
 use crate::encoded_item::EncodedItemArrayCtx;
 use crate::encoded_value::EncodedArray;
 use crate::error::Error;
@@ -16,7 +15,7 @@ use crate::jtype::Type;
 use crate::method::EncodedMethodArray;
 use crate::method::Method;
 use crate::source::Source;
-use crate::string::JString;
+use crate::string::DexString;
 use crate::uint;
 
 /// `ClassId` is an index into the Types section. The corresponding `Type` denotes the type of
@@ -64,7 +63,7 @@ pub struct Class {
     pub(crate) annotations: Option<AnnotationsDirectoryItem>,
     /// The file in which this class is found in the source code.
     #[get = "pub"]
-    pub(crate) source_file: Option<Ref<JString>>,
+    pub(crate) source_file: Option<DexString>,
     /// Static fields defined in the class.
     pub(crate) static_fields: Vec<Field>,
     /// Instance fields defined in the class.

--- a/src/code.rs
+++ b/src/code.rs
@@ -4,11 +4,10 @@ use std::fmt;
 
 use getset::{CopyGetters, Getters};
 
-use crate::cache::Ref;
 use crate::encoded_item::EncodedCatchHandlers;
 use crate::error::Error;
 use crate::jtype::Type;
-use crate::string::JString;
+use crate::string::DexString;
 use crate::uint;
 use crate::ulong;
 use crate::ushort;
@@ -20,7 +19,7 @@ pub struct DebugInfoItem {
     #[get_copy = "pub"]
     line_start: usize,
     #[get = "pub"]
-    parameter_names: Vec<Option<Ref<JString>>>,
+    parameter_names: Vec<Option<DexString>>,
 }
 
 /// Code and Debug Info of a method.

--- a/src/dex.rs
+++ b/src/dex.rs
@@ -13,7 +13,6 @@ use super::Result;
 use crate::annotation::{
     AnnotationItem, AnnotationSetItem, AnnotationSetRefList, AnnotationsDirectoryItem,
 };
-use crate::cache::Ref;
 use crate::class::Class;
 use crate::class::ClassDataItem;
 use crate::class::ClassDefItem;
@@ -36,7 +35,7 @@ use crate::method::ProtoId;
 use crate::method::ProtoIdItem;
 use crate::search::Section;
 use crate::source::Source;
-use crate::string::JString;
+use crate::string::DexString;
 use crate::string::StringId;
 use crate::string::Strings;
 use crate::string::StringsIter;
@@ -347,7 +346,7 @@ where
         self.inner.data_section().contains(&offset)
     }
 
-    pub(crate) fn get_source_file(&self, file_id: StringId) -> Result<Option<Ref<JString>>> {
+    pub(crate) fn get_source_file(&self, file_id: StringId) -> Result<Option<DexString>> {
         Ok(if file_id == NO_INDEX {
             None
         } else {
@@ -355,8 +354,8 @@ where
         })
     }
 
-    /// Returns a reference to the `JString` represented by the given id.
-    pub fn get_string(&self, string_id: StringId) -> Result<Ref<JString>> {
+    /// Returns a reference to the `DexString` represented by the given id.
+    pub fn get_string(&self, string_id: StringId) -> Result<DexString> {
         if self.inner.strings_len() <= string_id {
             return Err(Error::InvalidId(format!(
                 "Invalid string id: {}",
@@ -517,7 +516,7 @@ where
     }
 
     /// Iterator over the strings
-    pub fn strings(&self) -> impl Iterator<Item = Result<Ref<JString>>> {
+    pub fn strings(&self) -> impl Iterator<Item = Result<DexString>> {
         StringsIter::new(self.strings.clone(), self.inner.strings_len() as usize)
     }
 

--- a/src/encoded_value.rs
+++ b/src/encoded_value.rs
@@ -7,7 +7,6 @@ use scroll::Uleb128;
 use scroll::LE;
 
 use crate::annotation::EncodedAnnotation;
-use crate::cache::Ref;
 use crate::error::Error;
 use crate::field::FieldIdItem;
 use crate::int;
@@ -17,7 +16,7 @@ use crate::method::MethodHandleItem;
 use crate::method::MethodIdItem;
 use crate::method::ProtoIdItem;
 use crate::short;
-use crate::string::JString;
+use crate::string::DexString;
 use crate::ubyte;
 use crate::uint;
 use crate::ulong;
@@ -38,7 +37,7 @@ pub enum EncodedValue {
     Double(f64),
     MethodType(ProtoIdItem),
     MethodHandle(MethodHandleItem),
-    String(Ref<JString>),
+    String(DexString),
     Field(FieldIdItem),
     Method(MethodIdItem),
     Annotation(EncodedAnnotation),

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,13 +1,12 @@
 //! Dex `Field` and supporting structures
 use scroll::{ctx, Pread, Uleb128};
 
-use crate::cache::Ref;
 use crate::class::ClassId;
 use crate::encoded_item::EncodedItem;
 use crate::encoded_item::EncodedItemArray;
 use crate::error::Error;
 use crate::jtype::Type;
-use crate::string::JString;
+use crate::string::DexString;
 use crate::string::StringId;
 use crate::uint;
 use crate::ulong;
@@ -35,7 +34,7 @@ bitflags! {
 pub struct Field {
     /// Name of the field.
     #[get = "pub"]
-    name: Ref<JString>,
+    name: DexString,
     /// Type of the field.
     #[get = "pub"]
     jtype: Type,

--- a/src/jtype.rs
+++ b/src/jtype.rs
@@ -4,8 +4,7 @@ use std::fmt;
 
 use getset::{CopyGetters, Getters};
 
-use crate::cache::Ref;
-use crate::string::JString;
+use crate::string::DexString;
 use crate::uint;
 
 pub type TypeId = uint;
@@ -19,7 +18,7 @@ pub struct Type {
     pub(crate) id: TypeId,
     /// The type descriptor string for this string.
     #[get = "pub"]
-    pub(crate) type_descriptor: Ref<JString>,
+    pub(crate) type_descriptor: DexString,
 }
 
 impl Clone for Type {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod jtype;
 pub mod method;
 mod search;
 mod source;
-mod string;
+pub mod string;
 
 /// The constant NO_INDEX is used to indicate that an index value is absent.
 pub const NO_INDEX: uint = 0xffff_ffff;

--- a/src/method.rs
+++ b/src/method.rs
@@ -6,7 +6,6 @@ use scroll::ctx;
 use scroll::Pread;
 use scroll::Uleb128;
 
-use crate::cache::Ref;
 use crate::code::CodeItem;
 use crate::encoded_item::EncodedItem;
 use crate::encoded_item::EncodedItemArray;
@@ -14,7 +13,7 @@ use crate::error::Error;
 use crate::field::FieldId;
 use crate::jtype::Type;
 use crate::jtype::TypeId;
-use crate::string::JString;
+use crate::string::DexString;
 use crate::string::StringId;
 use crate::uint;
 use crate::ulong;
@@ -49,7 +48,7 @@ pub struct Method {
     class: Type,
     /// Name of the method.
     #[get = "pub"]
-    name: Ref<JString>,
+    name: DexString,
     /// Access flags of the method.
     #[get_copy = "pub"]
     access_flags: AccessFlags,
@@ -59,7 +58,7 @@ pub struct Method {
     /// Shorty descriptor of the method. Conforms to
     /// https://source.android.com/devices/tech/dalvik/dex-format#shortydescriptor
     #[get = "pub"]
-    shorty: Ref<JString>,
+    shorty: DexString,
     /// Return type of the method.
     #[get = "pub"]
     return_type: Type,


### PR DESCRIPTION
* Renamed JString to DexString
* Removed Ref type and made DexString ref-counted wrapper over String. `Ref` needs to be exposed outside the crate unnecessarily. 