### PR TITLE
Organize imports and fix Id usages

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -1,18 +1,13 @@
 //! Structures for Annotations on a `Class`, `Method`, `MethodParams` and `Field`s.
-use scroll::ctx;
-use scroll::Pread;
-use scroll::Uleb128;
+use scroll::{ctx, Pread, Uleb128};
 use std::ops::Deref;
 
 use getset::{CopyGetters, Getters};
 
-use crate::encoded_value::EncodedValue;
-use crate::error::Error;
-use crate::field::FieldId;
-use crate::jtype::TypeId;
-use crate::method::MethodId;
-use crate::string::StringId;
-use crate::{ubyte, uint};
+use crate::{
+    encoded_value::EncodedValue, error::Error, field::FieldId, jtype::TypeId, method::MethodId,
+    string::StringId, ubyte, uint,
+};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,4 @@
-use std::cell::RefCell;
-use std::cmp::Eq;
-use std::hash::Hash;
-use std::rc::Rc;
+use std::{cell::RefCell, cmp::Eq, hash::Hash, rc::Rc};
 
 use lru::LruCache;
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -2,20 +2,19 @@
 use std::clone::Clone;
 
 use getset::{CopyGetters, Getters};
-use scroll::ctx;
-use scroll::{Pread, Uleb128};
+use scroll::{ctx, Pread, Uleb128};
 
-use crate::annotation::{AnnotationSetItem, AnnotationsDirectoryItem};
-use crate::encoded_item::EncodedItemArrayCtx;
-use crate::error::Error;
-use crate::field::EncodedFieldArray;
-use crate::field::Field;
-use crate::jtype::Type;
-use crate::method::EncodedMethodArray;
-use crate::method::Method;
-use crate::source::Source;
-use crate::string::DexString;
-use crate::uint;
+use crate::{
+    annotation::{AnnotationSetItem, AnnotationsDirectoryItem},
+    encoded_item::EncodedItemArrayCtx,
+    error::Error,
+    field::{EncodedFieldArray, Field},
+    jtype::Type,
+    method::{EncodedMethodArray, Method},
+    source::Source,
+    string::DexString,
+    uint,
+};
 
 /// `ClassId` is an index into the Types section. The corresponding `Type` denotes the type of
 /// this class. The `Type` must be a class type, not a primitive or an array.

--- a/src/code.rs
+++ b/src/code.rs
@@ -1,16 +1,12 @@
-use scroll::ctx;
-use scroll::{Pread, Uleb128};
+use scroll::{ctx, Pread, Uleb128};
 use std::fmt;
 
 use getset::{CopyGetters, Getters};
 
-use crate::encoded_item::EncodedCatchHandlers;
-use crate::error::Error;
-use crate::jtype::Type;
-use crate::string::DexString;
-use crate::uint;
-use crate::ulong;
-use crate::ushort;
+use crate::{
+    encoded_item::EncodedCatchHandlers, error::Error, jtype::Type, string::DexString, uint, ulong,
+    ushort,
+};
 
 /// Debug Info of a method.
 /// [Android docs](https://source.android.com/devices/tech/dalvik/dex-format#debug-info-item)

--- a/src/dex.rs
+++ b/src/dex.rs
@@ -1,53 +1,31 @@
-use std::fs::File;
-use std::io::BufReader;
-use std::ops::Range;
+use std::{fs::File, io::BufReader, ops::Range};
 
 use adler32;
 use getset::{CopyGetters, Getters};
-use memmap::Mmap;
-use memmap::MmapOptions;
+use memmap::{Mmap, MmapOptions};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use scroll::ctx;
-use scroll::Pread;
+use scroll::{ctx, Pread};
 
 use super::Result;
-use crate::annotation::{
-    AnnotationItem, AnnotationSetItem, AnnotationSetRefList, AnnotationsDirectoryItem,
+use crate::{
+    annotation::{
+        AnnotationItem, AnnotationSetItem, AnnotationSetRefList, AnnotationsDirectoryItem,
+    },
+    class::{Class, ClassDataItem, ClassDefItem, ClassDefItemIter},
+    code::{CodeItem, DebugInfoItem},
+    encoded_value::{EncodedArray, EncodedValue},
+    error::{self, Error},
+    field::{EncodedField, Field, FieldId, FieldIdItem},
+    jtype::{Type, TypeId},
+    method::{
+        EncodedMethod, Method, MethodHandleItem, MethodId, MethodIdItem, ProtoId, ProtoIdItem,
+    },
+    search::Section,
+    source::Source,
+    string::{DexString, StringId, Strings, StringsIter},
+    ubyte, uint, ulong, ushort, utils, Endian, ENDIAN_CONSTANT, NO_INDEX, REVERSE_ENDIAN_CONSTANT,
 };
-use crate::class::Class;
-use crate::class::ClassDataItem;
-use crate::class::ClassDefItem;
-use crate::class::ClassDefItemIter;
-use crate::code::{CodeItem, DebugInfoItem};
-use crate::encoded_value::{EncodedArray, EncodedValue};
-use crate::error::{self, Error};
-use crate::field::EncodedField;
-use crate::field::Field;
-use crate::field::FieldId;
-use crate::field::FieldIdItem;
-use crate::jtype::Type;
-use crate::jtype::TypeId;
-use crate::method::EncodedMethod;
-use crate::method::Method;
-use crate::method::MethodHandleItem;
-use crate::method::MethodId;
-use crate::method::MethodIdItem;
-use crate::method::ProtoId;
-use crate::method::ProtoIdItem;
-use crate::search::Section;
-use crate::source::Source;
-use crate::string::DexString;
-use crate::string::StringId;
-use crate::string::Strings;
-use crate::string::StringsIter;
-use crate::ubyte;
-use crate::uint;
-use crate::ulong;
-use crate::ushort;
-use crate::utils;
-use crate::Endian;
-use crate::{ENDIAN_CONSTANT, NO_INDEX, REVERSE_ENDIAN_CONSTANT};
 use std::path::Path;
 
 /// Dex file header

--- a/src/encoded_item.rs
+++ b/src/encoded_item.rs
@@ -1,17 +1,13 @@
-use scroll::ctx;
-use scroll::Pread;
-use scroll::Sleb128;
-use scroll::Uleb128;
+use scroll::{ctx, Pread, Sleb128, Uleb128};
 
 use getset::Getters;
 
-use crate::code::CatchHandler;
-use crate::code::ExceptionType;
-use crate::error::Error;
-use crate::jtype::TypeId;
-use crate::uint;
-use crate::ulong;
-use crate::ushort;
+use crate::{
+    code::{CatchHandler, ExceptionType},
+    error::Error,
+    jtype::TypeId,
+    uint, ulong, ushort,
+};
 
 pub trait EncodedItem {
     /// Returns the id of the encoded item.

--- a/src/encoded_value.rs
+++ b/src/encoded_value.rs
@@ -7,14 +7,14 @@ use crate::{
     annotation::EncodedAnnotation,
     byte,
     error::Error,
-    field::FieldIdItem,
+    field::{FieldId, FieldIdItem},
     int,
-    jtype::Type,
+    jtype::{Type, TypeId},
     long,
-    method::{MethodHandleItem, MethodIdItem, ProtoIdItem},
+    method::{MethodHandleItem, MethodId, MethodIdItem, ProtoId, ProtoIdItem},
     short,
-    string::DexString,
-    ubyte, uint, ulong, ushort, Result,
+    string::{DexString, StringId},
+    ubyte, uint, ushort, Result,
 };
 
 /// Used to represent values of fields, annotations etc.
@@ -155,7 +155,7 @@ where
             ValueType::MethodType => {
                 debug_assert!(value_arg < 4);
                 let proto_id: uint = try_extended_gread!(source, offset, value_arg, 4);
-                EncodedValue::MethodType(dex.get_proto_item(u64::from(proto_id))?)
+                EncodedValue::MethodType(dex.get_proto_item(ProtoId::from(proto_id))?)
             }
             ValueType::MethodHandle => {
                 debug_assert!(value_arg < 4);
@@ -164,28 +164,28 @@ where
             }
             ValueType::String => {
                 debug_assert!(value_arg < 4);
-                let index: uint = try_extended_gread!(source, offset, value_arg, 4);
-                EncodedValue::String(dex.get_string(index)?)
+                let string_id: StringId = try_extended_gread!(source, offset, value_arg, 4);
+                EncodedValue::String(dex.get_string(string_id)?)
             }
             ValueType::Type => {
                 debug_assert!(value_arg < 4);
-                let index: uint = try_extended_gread!(source, offset, value_arg, 4);
-                EncodedValue::Type(dex.get_type(index)?)
+                let type_id: TypeId = try_extended_gread!(source, offset, value_arg, 4);
+                EncodedValue::Type(dex.get_type(type_id)?)
             }
             ValueType::Field => {
                 debug_assert!(value_arg < 4);
                 let index: uint = try_extended_gread!(source, offset, value_arg, 4);
-                EncodedValue::Field(dex.get_field_item(ulong::from(index))?)
+                EncodedValue::Field(dex.get_field_item(FieldId::from(index))?)
             }
             ValueType::Method => {
                 debug_assert!(value_arg < 4);
                 let index: uint = try_extended_gread!(source, offset, value_arg, 4);
-                EncodedValue::Method(dex.get_method_item(ulong::from(index))?)
+                EncodedValue::Method(dex.get_method_item(MethodId::from(index))?)
             }
             ValueType::Enum => {
                 debug_assert!(value_arg < 4);
                 let index: uint = try_extended_gread!(source, offset, value_arg, 4);
-                EncodedValue::Enum(dex.get_field_item(ulong::from(index))?)
+                EncodedValue::Enum(dex.get_field_item(FieldId::from(index))?)
             }
             ValueType::Array => {
                 debug_assert!(value_arg == 0);

--- a/src/encoded_value.rs
+++ b/src/encoded_value.rs
@@ -1,27 +1,21 @@
 //! Contains structures defining values in a `Dex`.
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use scroll::Pread;
-use scroll::Uleb128;
-use scroll::LE;
-use scroll::{self, ctx};
+use scroll::{self, ctx, Pread, Uleb128, LE};
 
-use crate::annotation::EncodedAnnotation;
-use crate::error::Error;
-use crate::field::FieldIdItem;
-use crate::int;
-use crate::jtype::Type;
-use crate::long;
-use crate::method::MethodHandleItem;
-use crate::method::MethodIdItem;
-use crate::method::ProtoIdItem;
-use crate::short;
-use crate::string::DexString;
-use crate::uint;
-use crate::ulong;
-use crate::ushort;
-use crate::Result;
-use crate::{byte, ubyte};
+use crate::{
+    annotation::EncodedAnnotation,
+    byte,
+    error::Error,
+    field::FieldIdItem,
+    int,
+    jtype::Type,
+    long,
+    method::{MethodHandleItem, MethodIdItem, ProtoIdItem},
+    short,
+    string::DexString,
+    ubyte, uint, ulong, ushort, Result,
+};
 
 /// Used to represent values of fields, annotations etc.
 /// [Android docs](https://source.android.com/devices/tech/dalvik/dex-format#encoding)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
-use std::error;
-use std::fmt::{self, Display};
-use std::io;
+use std::{
+    error,
+    fmt::{self, Display},
+    io,
+};
 
 use scroll;
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -7,9 +7,9 @@ use crate::{
     encoded_item::{EncodedItem, EncodedItemArray},
     encoded_value::EncodedValue,
     error::Error,
-    jtype::Type,
+    jtype::{Type, TypeId},
     string::{DexString, StringId},
-    uint, ulong, ushort,
+    ulong, ushort,
 };
 use getset::{CopyGetters, Getters};
 
@@ -66,8 +66,8 @@ impl Field {
         debug!(target: "field", "field id item: {:?}", field_item);
         Ok(Self {
             name: dex.get_string(field_item.name_idx)?,
-            jtype: dex.get_type(uint::from(field_item.type_idx))?,
-            class: uint::from(field_item.class_idx),
+            jtype: dex.get_type(TypeId::from(field_item.type_idx))?,
+            class: ClassId::from(field_item.class_idx),
             access_flags: AccessFlags::from_bits(encoded_field.access_flags).ok_or_else(|| {
                 Error::InvalidId(format!(
                     "Invalid access flags when loading field {}",

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,18 +1,16 @@
 //! Dex `Field` and supporting structures
 use scroll::{ctx, Pread, Uleb128};
 
-use crate::annotation::AnnotationSetItem;
-use crate::class::ClassId;
-use crate::encoded_item::EncodedItem;
-use crate::encoded_item::EncodedItemArray;
-use crate::encoded_value::EncodedValue;
-use crate::error::Error;
-use crate::jtype::Type;
-use crate::string::DexString;
-use crate::string::StringId;
-use crate::uint;
-use crate::ulong;
-use crate::ushort;
+use crate::{
+    annotation::AnnotationSetItem,
+    class::ClassId,
+    encoded_item::{EncodedItem, EncodedItemArray},
+    encoded_value::EncodedValue,
+    error::Error,
+    jtype::Type,
+    string::{DexString, StringId},
+    uint, ulong, ushort,
+};
 use getset::{CopyGetters, Getters};
 
 bitflags! {

--- a/src/jtype.rs
+++ b/src/jtype.rs
@@ -1,11 +1,9 @@
 //! Dex `Type` and utilities
-use std::clone::Clone;
-use std::fmt;
+use std::{clone::Clone, fmt};
 
 use getset::{CopyGetters, Getters};
 
-use crate::string::DexString;
-use crate::uint;
+use crate::{string::DexString, uint};
 
 /// Offset into the `TypeId`s section.
 pub type TypeId = uint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,7 @@ use scroll;
 
 pub use error::Error;
 
-pub use crate::dex::Dex;
-pub use crate::dex::DexReader;
+pub use crate::dex::{Dex, DexReader};
 
 #[macro_use]
 mod utils;

--- a/src/method.rs
+++ b/src/method.rs
@@ -107,7 +107,7 @@ impl Method {
         let method_item = dex.get_method_item(encoded_method.method_id)?;
         let name = dex.get_string(method_item.name_idx)?;
         debug!(target: "method", "name: {}, method id item: {:?}", name, method_item);
-        let proto_item = dex.get_proto_item(ulong::from(method_item.proto_idx))?;
+        let proto_item = dex.get_proto_item(ProtoId::from(method_item.proto_idx))?;
         debug!(target: "method", "method proto_item: {:?}", proto_item);
         let shorty = dex.get_string(proto_item.shorty)?;
         let return_type = dex.get_type(proto_item.return_type)?;
@@ -133,7 +133,7 @@ impl Method {
         let code = dex.get_code_item(encoded_method.code_offset)?;
         Ok(Self {
             name,
-            class: dex.get_type(uint::from(method_item.class_idx))?,
+            class: dex.get_type(TypeId::from(method_item.class_idx))?,
             access_flags: AccessFlags::from_bits(encoded_method.access_flags).ok_or_else(|| {
                 Error::InvalidId(format!(
                     "Invalid access flags for method {}",

--- a/src/method.rs
+++ b/src/method.rs
@@ -2,24 +2,18 @@
 use getset::{CopyGetters, Getters};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use scroll::ctx;
-use scroll::Pread;
-use scroll::Uleb128;
+use scroll::{ctx, Pread, Uleb128};
 
-use crate::annotation::{AnnotationSetItem, AnnotationSetRefList};
-use crate::code::CodeItem;
-use crate::encoded_item::EncodedItem;
-use crate::encoded_item::EncodedItemArray;
-use crate::error::Error;
-use crate::field::FieldId;
-use crate::jtype::Type;
-use crate::jtype::TypeId;
-use crate::string::DexString;
-use crate::string::StringId;
-use crate::uint;
-use crate::ulong;
-use crate::ushort;
-use crate::utils;
+use crate::{
+    annotation::{AnnotationSetItem, AnnotationSetRefList},
+    code::CodeItem,
+    encoded_item::{EncodedItem, EncodedItemArray},
+    error::Error,
+    field::FieldId,
+    jtype::{Type, TypeId},
+    string::{DexString, StringId},
+    uint, ulong, ushort, utils,
+};
 
 bitflags! {
     /// Access flags of a `Dex` Method

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,8 +1,6 @@
 use crate::Result;
-use scroll::ctx;
-use scroll::Pread;
-use std::cmp::Ordering;
-use std::fmt::Debug;
+use scroll::{ctx, Pread};
+use std::{cmp::Ordering, fmt::Debug};
 
 pub(crate) struct Section<'a> {
     inner: &'a [u8],

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,7 +1,4 @@
-use std::clone::Clone;
-use std::convert::AsRef;
-use std::ops::Index;
-use std::rc::Rc;
+use std::{clone::Clone, convert::AsRef, ops::Index, rc::Rc};
 
 use crate::ubyte;
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,18 +1,14 @@
 //! Dex String utilities
-use std::convert::AsRef;
-use std::fmt;
-use std::ops::Deref;
-use std::ops::Range;
+use std::{
+    convert::AsRef,
+    fmt,
+    ops::{Deref, Range},
+};
 
 use cesu8::{from_java_cesu8, to_java_cesu8};
 use scroll::{self, ctx, Pread, Uleb128};
 
-use crate::cache::Cache;
-use crate::error;
-use crate::error::Error;
-use crate::source::Source;
-use crate::uint;
-use crate::Result;
+use crate::{cache::Cache, error, error::Error, source::Source, uint, Result};
 use std::rc::Rc;
 
 /// Index into the `StringId`s section.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,8 @@
-use crate::encoded_item::EncodedItem;
-use crate::encoded_item::EncodedItemArray;
-use crate::jtype::{Type, TypeId};
-use crate::ushort;
+use crate::{
+    encoded_item::{EncodedItem, EncodedItemArray},
+    jtype::{Type, TypeId},
+    ushort,
+};
 
 macro_rules! try_gread_vec_with {
     ($source:ident,$offset:ident,$cap:expr,$ctx:expr) => {{

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,8 @@
-use std::env;
-use std::fs;
-use std::path::Path;
-use std::path::PathBuf;
-use std::process::Command;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use tempfile::TempDir;
 


### PR DESCRIPTION
* Using trees for use statements.
* Use StringId, TypeId, ClassId etc. where possible instead of uint, etc.