### PR TITLE
Add methods to read access flags

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -76,6 +76,17 @@ pub struct Class {
 }
 
 impl Class {
+    gen_is_flag_set!(is_public, PUBLIC);
+    gen_is_flag_set!(is_private, PRIVATE);
+    gen_is_flag_set!(is_protected, PROTECTED);
+    gen_is_flag_set!(is_static, STATIC);
+    gen_is_flag_set!(is_final, FINAL);
+    gen_is_flag_set!(is_interface, INTERFACE);
+    gen_is_flag_set!(is_abstract, ABSTRACT);
+    gen_is_flag_set!(is_synthetic, SYNTHETIC);
+    gen_is_flag_set!(is_annotation, ANNOTATION);
+    gen_is_flag_set!(is_enum, ENUM);
+
     /// The file in which this class is found in the source code.
     pub fn source_file(&self) -> Option<&DexString> {
         self.source_file.as_ref()

--- a/src/field.rs
+++ b/src/field.rs
@@ -24,7 +24,6 @@ bitflags! {
         const VOLATILE = 0x40;
         const TRANSIENT = 0x80;
         const SYNTHETIC = 0x1000;
-        const ANNOTATION = 0x2000;
         const ENUM = 0x4000;
     }
 }
@@ -60,6 +59,16 @@ impl Field {
     pub fn initial_value(&self) -> Option<&EncodedValue> {
         self.initial_value.as_ref()
     }
+
+    gen_is_flag_set!(is_public, PUBLIC);
+    gen_is_flag_set!(is_private, PRIVATE);
+    gen_is_flag_set!(is_protected, PROTECTED);
+    gen_is_flag_set!(is_static, STATIC);
+    gen_is_flag_set!(is_final, FINAL);
+    gen_is_flag_set!(is_volatile, VOLATILE);
+    gen_is_flag_set!(is_transient, TRANSIENT);
+    gen_is_flag_set!(is_synthetic, SYNTHETIC);
+    gen_is_flag_set!(is_enum, ENUM);
 
     pub(crate) fn try_from_dex<S: AsRef<[u8]>>(
         dex: &super::Dex<S>,

--- a/src/method.rs
+++ b/src/method.rs
@@ -68,6 +68,21 @@ pub struct Method {
 }
 
 impl Method {
+    gen_is_flag_set!(is_public, PUBLIC);
+    gen_is_flag_set!(is_private, PRIVATE);
+    gen_is_flag_set!(is_protected, PROTECTED);
+    gen_is_flag_set!(is_static, STATIC);
+    gen_is_flag_set!(is_final, FINAL);
+    gen_is_flag_set!(is_synchronized, SYNCHRONIZED);
+    gen_is_flag_set!(is_bridge, BRIDGE);
+    gen_is_flag_set!(is_varargs, VARARGS);
+    gen_is_flag_set!(is_native, NATIVE);
+    gen_is_flag_set!(is_abstract, ABSTRACT);
+    gen_is_flag_set!(is_strict, STRICT);
+    gen_is_flag_set!(is_synthetic, SYNTHETIC);
+    gen_is_flag_set!(is_constructor, CONSTRUCTOR);
+    gen_is_flag_set!(is_declared_synchronized, DECLARED_SYNCHRONIZED);
+
     /// Code and DebugInfo of the method.
     pub fn code(&self) -> Option<&CodeItem> {
         self.code.as_ref()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,3 +59,12 @@ where
         .map(|type_id| dex.get_type(TypeId::from(*type_id)))
         .collect()
 }
+
+macro_rules! gen_is_flag_set {
+    ($name: ident, $flag: ident) => {
+        /// Returns `true` if the access flag is set
+        pub fn $name(&self) -> bool {
+            self.access_flags().contains(AccessFlags::$flag)
+        }
+    }
+}


### PR DESCRIPTION
* Bug fix: Field access flags struct shouldn't have Annotation type, but it was there. Removed it.
* Added methods `is_$flag` for all access flags of a class, method, field.