### PR TITLE
Fix: superclass isn't populated to the class struct

### DIFF
--- a/src/class.rs
+++ b/src/class.rs
@@ -185,7 +185,7 @@ impl Class {
             .unwrap_or_else(|| Ok::<_, Error>(Default::default()))?;
 
         debug!(target: "class", "super class id: {}", class_def.superclass_idx);
-        let super_class = if class_def.superclass_idx == super::NO_INDEX {
+        let super_class = if class_def.superclass_idx != super::NO_INDEX {
             Some(class_def.superclass_idx)
         } else {
             None

--- a/src/dex.rs
+++ b/src/dex.rs
@@ -95,7 +95,7 @@ pub struct Header {
 
 impl Header {
     fn data_section(&self) -> Range<uint> {
-        (self.data_off..self.data_off + self.data_size)
+        self.data_off..self.data_off + self.data_size
     }
 }
 


### PR DESCRIPTION
Thanks for working on dex parser in Rust. Just realized the super class field isn't correctly handled. So just have the simple fix. Thanks! 