### PR TITLE
Support for loading dex files from in memory vecs

### DIFF
--- a/src/dex.rs
+++ b/src/dex.rs
@@ -772,22 +772,73 @@ impl DexReader {
             inner,
         })
     }
+
+    /// Loads a `Dex` from a `Vec<u8>`
+    pub fn from_vec(vec: Vec<u8>) -> Result<Dex<Vec<u8>>> {
+        let inner: DexInner = vec.pread(0)?;
+        let endian = inner.endian();
+        let source = Source::new(vec);
+        let cache = Strings::new(
+            source.clone(),
+            endian,
+            inner.strings_offset(),
+            inner.strings_len(),
+            4096,
+            inner.data_section(),
+        );
+        Ok(Dex {
+            source: source.clone(),
+            strings: cache,
+            inner,
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
 
+    use memmap::MmapOptions;
+    use std::fs::File;
+    use super::Result;
+    use std::path::Path;
+
     #[test]
     fn test_find_class_by_name() {
         let dex =
             super::DexReader::from_file("resources/classes.dex").expect("cannot open dex file");
+        let mut count = 0;
         for class_def in dex.class_defs() {
             let class_def = class_def.expect("can't load class");
             let jtype = dex.get_type(class_def.class_idx()).expect("bad type");
             let result = dex.find_class_by_name(&jtype.type_descriptor().to_string());
             assert!(result.is_ok());
             assert!(result.unwrap().is_some());
+            count += 1;
         }
+        assert!(count > 0);
+    }
+
+    fn load_example_dex_as_vec<P: AsRef<Path>>(file: P) -> Result<Vec<u8>> {
+        let map = unsafe { MmapOptions::new().map(&File::open(file.as_ref())?)? };
+        let data = map.to_vec();
+        Ok(data)
+    }
+
+    #[test]
+    fn test_find_class_by_name_from_vec() {
+        let data: Vec<u8> = load_example_dex_as_vec("resources/classes.dex")
+            .expect("Cannot load example file to a vec");
+        let dex = super::DexReader::from_vec(data).expect("Cannot parse dex from vec");
+        let mut count = 0;
+        for class_def in dex.class_defs() {
+            let class_def = class_def.expect("can't load class");
+            let jtype = dex.get_type(class_def.class_idx()).expect("bad type");
+            let result = dex.find_class_by_name(&jtype.type_descriptor().to_string());
+            assert!(result.is_ok());
+            assert!(result.unwrap().is_some());
+            count += 1;
+        }
+        assert!(count > 0);
     }
 
     #[test]

--- a/src/dex.rs
+++ b/src/dex.rs
@@ -774,10 +774,10 @@ impl DexReader {
     }
 
     /// Loads a `Dex` from a `Vec<u8>`
-    pub fn from_vec(vec: Vec<u8>) -> Result<Dex<Vec<u8>>> {
-        let inner: DexInner = vec.pread(0)?;
+    pub fn from_vec<B: AsRef<[u8]>>(buf: B) -> Result<Dex<B>> {
+        let inner: DexInner = buf.as_ref().pread(0)?;
         let endian = inner.endian();
-        let source = Source::new(vec);
+        let source = Source::new(buf);
         let cache = Strings::new(
             source.clone(),
             endian,


### PR DESCRIPTION
Hi, I added a method for loading dex files from a `Vec<u8>`. This can be useful if you are decompressing in-memory an apk and don't want to put the dex files in files. I copied the same test case for `from_file` to test the method.