### PR TITLE
Expose FieldId and MethodId

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -50,6 +50,9 @@ pub struct Field {
     /// Annotations of the field.
     #[get = "pub"]
     annotations: AnnotationSetItem,
+    /// `FieldId` of the field.
+    #[get = "pub"]
+    id: FieldId,
 }
 
 impl Field {
@@ -96,6 +99,7 @@ impl Field {
             })?,
             initial_value,
             annotations,
+            id: encoded_field.field_id,
         })
     }
 }

--- a/src/method.rs
+++ b/src/method.rs
@@ -65,6 +65,9 @@ pub struct Method {
     /// Annotations of the params.
     #[get = "pub"]
     param_annotations: AnnotationSetRefList,
+    /// `MethodId` of the method.
+    #[get = "pub"]
+    id: MethodId,
 }
 
 impl Method {
@@ -172,6 +175,7 @@ impl Method {
             code,
             annotations,
             param_annotations,
+            id: encoded_method.method_id,
         })
     }
 }


### PR DESCRIPTION
This is currently missing in Fields and Methods, and thus makes it
harder to associate them with other references in the Dex.