### PR TITLE
Add PackedSwitchPayload and SparseSwitchPayload

### DIFF
--- a/src/dex.rs
+++ b/src/dex.rs
@@ -13,7 +13,7 @@ use crate::{
         AnnotationItem, AnnotationSetItem, AnnotationSetRefList, AnnotationsDirectoryItem,
     },
     class::{Class, ClassDataItem, ClassDefItem, ClassDefItemIter},
-    code::{CodeItem, DebugInfoItem},
+    code::{CodeItem, DebugInfoItem, PackedSwitchPayload, SparseSwitchPayload},
     encoded_value::{EncodedArray, EncodedValue},
     error::{self, Error},
     field::{EncodedField, Field, FieldId, FieldIdItem},
@@ -744,6 +744,16 @@ where
         }
 
         Ok(self.source.pread_with(debug_info_off as usize, self)?)
+    }
+
+    /// Returns the `PackedSwitchPayload` at the offset.
+    pub fn get_packed_switch_payload(&self, packed_switch_off: uint) -> Result<PackedSwitchPayload> {
+        Ok(self.source.pread_with(packed_switch_off as usize, self)?)
+    }
+
+    /// Returns the `SparseSwitchPayload` at the offset.
+    pub fn get_sparse_switch_payload(&self, sparse_switch_off: uint) -> Result<SparseSwitchPayload> {
+        Ok(self.source.pread_with(sparse_switch_off as usize, self)?)
     }
 }
 


### PR DESCRIPTION
For parsing switch tables in Dex code.

Before this can be merged, the problem of associating the two needs to be solved. 

The `packed-switch` instruction has its 2nd argument as: "signed "branch" offset to table data pseudo-instruction (32 bits)". This is relative to the instruction, which means that it must be possible to get the offset of the start of the `insns` array first. How can we do this? It seems non-trivial with scroll because the `TryFromCtx` does not have global offset information, just a slice of bytes.