### PR TITLE
Expose more ids

### DIFF
--- a/src/dex.rs
+++ b/src/dex.rs
@@ -491,7 +491,7 @@ where
                 field_id
             )));
         }
-        FieldIdItem::try_from_dex(self, offset)
+        FieldIdItem::try_from_dex(self, offset, field_id)
     }
 
     /// Returns the `ProtoIdItem` represented by `ProtoId`.
@@ -523,7 +523,7 @@ where
                 method_id
             )));
         }
-        MethodIdItem::try_from_dex(self, offset)
+        MethodIdItem::try_from_dex(self, offset, method_id)
     }
 
     /// Iterator over the strings

--- a/src/field.rs
+++ b/src/field.rs
@@ -51,7 +51,7 @@ pub struct Field {
     #[get = "pub"]
     annotations: AnnotationSetItem,
     /// `FieldId` of the field.
-    #[get = "pub"]
+    #[get_copy = "pub"]
     id: FieldId,
 }
 
@@ -116,8 +116,8 @@ struct FieldIdData {
 
 /// Defines a `Field`
 /// [Android docs](https://source.android.com/devices/tech/dalvik/dex-format#field-id-item)
-#[derive(Debug, Getters, PartialEq)]
-#[get = "pub"]
+#[derive(Debug, CopyGetters, PartialEq)]
+#[get_copy = "pub"]
 pub struct FieldIdItem {
     /// Index into `TypeId`s list which contains the defining class's `Type`.
     class_idx: ushort,

--- a/src/field.rs
+++ b/src/field.rs
@@ -107,9 +107,16 @@ impl Field {
 /// List of `EncodedField`s
 pub type EncodedFieldArray = EncodedItemArray<EncodedField>;
 
+#[derive(Pread)]
+struct FieldIdData {
+    class_idx: ushort,
+    type_idx: ushort,
+    name_idx: StringId,
+}
+
 /// Defines a `Field`
 /// [Android docs](https://source.android.com/devices/tech/dalvik/dex-format#field-id-item)
-#[derive(Pread, Debug, Getters, PartialEq)]
+#[derive(Debug, Getters, PartialEq)]
 #[get = "pub"]
 pub struct FieldIdItem {
     /// Index into `TypeId`s list which contains the defining class's `Type`.
@@ -118,15 +125,24 @@ pub struct FieldIdItem {
     type_idx: ushort,
     /// Index into `StringId`s list which contains the name of the field.
     name_idx: StringId,
+    /// `FieldId` of this field.
+    id: FieldId,
 }
 
 impl FieldIdItem {
     pub(crate) fn try_from_dex<T: AsRef<[u8]>>(
         dex: &super::Dex<T>,
         offset: ulong,
+        field_id: FieldId,
     ) -> super::Result<Self> {
         let source = &dex.source;
-        Ok(source.pread_with(offset as usize, dex.get_endian())?)
+        let field: FieldIdData = source.pread_with(offset as usize, dex.get_endian())?;
+        Ok(FieldIdItem {
+            class_idx: field.class_idx,
+            type_idx: field.type_idx,
+            name_idx: field.name_idx,
+            id: field_id,
+        })
     }
 }
 

--- a/src/method.rs
+++ b/src/method.rs
@@ -66,7 +66,7 @@ pub struct Method {
     #[get = "pub"]
     param_annotations: AnnotationSetRefList,
     /// `MethodId` of the method.
-    #[get = "pub"]
+    #[get_copy = "pub"]
     id: MethodId,
 }
 

--- a/src/method.rs
+++ b/src/method.rs
@@ -180,9 +180,16 @@ impl Method {
     }
 }
 
+#[derive(Pread)]
+struct MethodIdData {
+    class_idx: ushort,
+    proto_idx: ushort,
+    name_idx: StringId,
+}
+
 /// Method identifier.
 /// [Android docs](https://source.android.com/devices/tech/dalvik/dex-format#method-id-item)
-#[derive(Pread, Debug, CopyGetters, PartialEq)]
+#[derive(Debug, CopyGetters, PartialEq)]
 #[get_copy = "pub"]
 pub struct MethodIdItem {
     /// Index into the `TypeId`s list for the definer of this method.
@@ -191,15 +198,24 @@ pub struct MethodIdItem {
     proto_idx: ushort,
     /// Index into the `StringId`s list for the name of this method.
     name_idx: StringId,
+    /// `MethodId` of this method.
+    id: MethodId,
 }
 
 impl MethodIdItem {
     pub(crate) fn try_from_dex<S: AsRef<[u8]>>(
         dex: &super::Dex<S>,
         offset: ulong,
+        method_id: MethodId,
     ) -> super::Result<Self> {
         let source = &dex.source;
-        Ok(source.pread_with(offset as usize, dex.get_endian())?)
+        let method: MethodIdData = source.pread_with(offset as usize, dex.get_endian())?;
+        Ok(MethodIdItem {
+            class_idx: method.class_idx,
+            proto_idx: method.proto_idx,
+            name_idx: method.name_idx,
+            id: method_id,
+        })
     }
 }
 


### PR DESCRIPTION
Reopened #45. This will help associating MethodIdFields with Methods/FieldIdFields with Fields and vice verca.

No new tests added, but old ones were amended to test the new functionality.

PS:
On my MacBook there is a regression in `test_annotations`, when trying to find `"LAnnotation;"`. This is unrelated to the changes made here and happens on master regardless.

I also changed `FieldIdItem` to derive from `CopyGetters` instead of `Copy` to be more inline with `MethodIdItem` and the `id` fields in `Method` and `Field` to copy getters, just like it is in `Class`