### PR TITLE
Add void type

### DIFF
--- a/src/jtype.rs
+++ b/src/jtype.rs
@@ -21,6 +21,8 @@ pub const LONG: &'static str = "J";
 pub const FLOAT: &'static str = "F";
 /// Dex representation of a double type
 pub const DOUBLE: &'static str = "D";
+/// Dex representation of a void type
+pub const VOID: &'static str = "V";
 
 /// Offset into the `TypeId`s section.
 pub type TypeId = uint;
@@ -56,6 +58,7 @@ impl Type {
             || self.is_long()
             || self.is_float()
             || self.is_double()
+            || self.is_void()
     }
 
     /// Returns `true` if the type is an array or a class
@@ -101,6 +104,7 @@ impl Type {
     gen_is_type_method!(is_long, LONG, "Returns `true` if the type is a long");
     gen_is_type_method!(is_float, FLOAT, "Returns `true` if the type is a float");
     gen_is_type_method!(is_double, DOUBLE, "Returns `true` if the type is a double");
+    gen_is_type_method!(is_void, VOID, "Returns `true` if the type is void");
 }
 
 fn to_java_type(s: &str) -> String {
@@ -113,6 +117,7 @@ fn to_java_type(s: &str) -> String {
         LONG => "long".to_string(),
         FLOAT => "float".to_string(),
         DOUBLE => "double".to_string(),
+        VOID => "void".to_string(),
         s if s.starts_with('L') => s[1..].replace('/', ".").replace(';', ""),
         s if s.starts_with('[') => {
             let d = s.chars().take_while(|c| *c == '[').count();
@@ -176,6 +181,7 @@ mod tests {
         assert_eq!(to_java_type(super::LONG), "long");
         assert_eq!(to_java_type(super::FLOAT), "float");
         assert_eq!(to_java_type(super::DOUBLE), "double");
+        assert_eq!(to_java_type(super::VOID), "void");
         assert_eq!(to_java_type("Ljava/lang/String;"), "java.lang.String");
         assert_eq!(to_java_type("[Ljava/lang/String;"), "java.lang.String[]");
         assert_eq!(to_java_type("[[Ljava/lang/String;"), "java.lang.String[][]");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -911,6 +911,67 @@ test!(
     }
 );
 
+test!(
+    test_builtin_types,
+    {
+        "BuiltInTypes.java" => r#"
+            public class BuiltInTypes {
+               boolean returnsBoolean() { return false; }
+               byte returnsByte() { return 0; }
+               short returnsShort() { return 0; }
+               char returnsChar() { return 0; }
+               int returnsInt() { return 0; }
+               long returnsLong() { return 0; }
+               float returnsFloat() { return 0; }
+               double returnsDouble() { return 0; }
+               // This is technically not needed, as the void type is always present
+               void returnsVoid() {}
+            }
+        "#
+    },
+    |dex: dex::Dex<_>| {
+        let builtin_class = dex.find_class_by_name("LBuiltInTypes;").unwrap().unwrap();
+
+        let find_type = |name: &str| {
+            dex.types().find(|t| {
+                if let Ok(t) = t {
+                    t.to_string() == name
+                } else {
+                    false
+                }
+            })
+        };
+
+        let boolean_type = find_type("Z");
+        assert!(boolean_type.is_some());
+
+        let byte_type = find_type("B");
+        assert!(byte_type.is_some());
+
+        let short_type = find_type("S");
+        assert!(short_type.is_some());
+
+        let char_type = find_type("C");
+        assert!(char_type.is_some());
+
+        let int_type = find_type("I");
+        assert!(int_type.is_some());
+
+        let long_type = find_type("J");
+        assert!(long_type.is_some());
+
+        let float_type = find_type("F");
+        assert!(float_type.is_some());
+
+        let double_type = find_type("D");
+        assert!(double_type.is_some());
+
+        let void_type = find_type("V");
+        assert!(void_type.is_some());
+
+    }
+);
+
 #[test]
 fn test_iterators() {
     use dex::DexReader;


### PR DESCRIPTION
This would previously make `to_java_type` panic (`unreachable!`).

Partly already tested in `test_methods`, but now there's a test if all the builtin types are properly parsed.