### PR TITLE
update env_logger to 0.11.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ adler32 = "1.0.4"
 
 [dev-dependencies]
 tempfile = "3.0.8"
-env_logger = "0.7.1"
+env_logger = "0.11.3"


### PR DESCRIPTION
removes the dependency on atty which has an unfixed rustsec [advisory]

[advisory]: https://rustsec.org/advisories/RUSTSEC-2021-0145