### PR TITLE
Add Debug trait to Dex structure

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,7 +3,8 @@ use std::{cell::RefCell, cmp::Eq, hash::Hash, num::NonZeroUsize, rc::Rc};
 use lru::LruCache;
 
 /// LRU cache that provides interior mutability
-pub(crate) struct Cache<K, V> {
+#[derive(Debug)]
+pub(crate) struct Cache<K: Hash + Eq, V> {
     inner: Rc<RefCell<LruCache<K, V>>>,
 }
 
@@ -29,7 +30,7 @@ impl<K: Hash + Eq, V: Clone> Cache<K, V> {
     }
 }
 
-impl<K, V> Clone for Cache<K, V> {
+impl<K: Hash + Eq, V> Clone for Cache<K, V> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),

--- a/src/dex.rs
+++ b/src/dex.rs
@@ -325,6 +325,7 @@ impl<'a> ctx::TryFromCtx<'a, Endian> for MapItem {
 }
 
 /// Represents a Dex file
+#[derive(Debug)]
 pub struct Dex<T> {
     /// Source from which this Dex file is loaded from.
     pub(crate) source: Source<T>,

--- a/src/source.rs
+++ b/src/source.rs
@@ -5,6 +5,7 @@ use crate::ubyte;
 /// Represents the source `Dex` file. This is a
 /// wrapper type that allows for shallow copies
 /// of the dex file's source.
+#[derive(Debug)]
 pub(crate) struct Source<T> {
     inner: Rc<T>,
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -88,6 +88,7 @@ impl<'a> ctx::TryFromCtx<'a, scroll::Endian> for DexString {
 /// To prevent encoding/decoding Java strings to Rust strings
 /// every time, we cache the strings in memory. This also potentially
 /// reduces I/O because strings are used in a lot of places.
+#[derive(Debug)]
 pub(crate) struct Strings<T> {
     source: Source<T>,
     ///  Offset into the strings section.


### PR DESCRIPTION
Implements Debug to the Dex struct allowing one to more easily check the components when using this crate as a library