### PR TITLE
Add HiddenAPIClassDataItem item type

### DIFF
--- a/src/dex.rs
+++ b/src/dex.rs
@@ -286,6 +286,7 @@ pub enum ItemType {
     AnnotationItem = 0x2004,
     EncodedArrayItem = 0x2005,
     AnnotationsDirectoryItem = 0x2006,
+    HiddenAPIClassDataItem = 0xF000,
 }
 
 /// Single item of the MapList.


### PR DESCRIPTION
Add a missing [item type](https://source.android.com/docs/core/runtime/dex-format#type-codes) for data on restricted interfaces used by each class. I don't think this can be tested with a unit test without actually embedding a binary `.dex` file, but it allows me to load the AOSP's `core-oj.jar/classes.dex` without any errors.